### PR TITLE
Ensure service pages interlink across cards and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,11 +70,11 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="#">D&amp;M</a>
+          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
-            <a class="border-b-2 border-cyan-400 pb-1 text-white" href="#">Anasayfa</a>
+            <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>
-            <a class="hover:text-white/80" href="#">Hizmetler</a>
+            <a class="hover:text-white/80" href="#hizmetler">Hizmetler</a>
             <a class="hover:text-white/80" href="#">S.S.S</a>
             <a class="hover:text-white/80" href="#">Medya</a>
             <a class="hover:text-white/80" href="#iletisim">İletişim</a>
@@ -181,23 +181,31 @@
             numarası üzerinden sunar.
           </p>
         </div>
-        <div class="mt-16 grid gap-8 sm:grid-cols-2 xl:grid-cols-4">
+        <div class="mt-16 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           <article class="group flex flex-col overflow-hidden rounded-3xl bg-white shadow-xl ring-1 ring-slate-100 transition duration-300 hover:-translate-y-1 hover:shadow-2xl">
-            <figure class="relative h-52 overflow-hidden">
-              <img
-                class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-                src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&amp;fit=crop&amp;w=800&amp;q=80"
-                alt="Petek temizliği yapan usta"
-              />
-              <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
-            </figure>
-            <div class="flex flex-1 flex-col p-6">
-              <h3 class="text-xl font-semibold text-slate-900">Petek Temizliği</h3>
-              <p class="mt-3 text-sm leading-relaxed text-slate-600">
-                Kimyasal ilaçlama ve makineli temizlikle peteklerinizdeki tortuyu gidererek ısınma performansını artırıyoruz.
-              </p>
-              <div class="mt-6 border-t border-slate-200 pt-4">
-                <a class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-cyan-600" href="tel:+905398168013">
+            <a class="flex flex-1 flex-col" href="petektemizligi.html">
+              <figure class="relative h-52 overflow-hidden">
+                <img
+                  class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                  src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&amp;fit=crop&amp;w=800&amp;q=80"
+                  alt="Petek temizliği yapan usta"
+                />
+                <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
+              </figure>
+              <div class="flex flex-1 flex-col p-6">
+                <h3 class="text-xl font-semibold text-slate-900">Petek Temizliği</h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-600">
+                  Kimyasal ilaçlama ve makineli temizlikle peteklerinizdeki tortuyu gidererek ısınma performansını artırıyoruz.
+                </p>
+              </div>
+            </a>
+            <div class="px-6 pb-6">
+              <div class="mt-6 flex items-center justify-between border-t border-slate-200 pt-4">
+                <a class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-cyan-600" href="petektemizligi.html">
+                  <span class="material-icons text-base">arrow_forward</span>
+                  <span>Hizmeti İncele</span>
+                </a>
+                <a class="inline-flex items-center gap-2 text-sm font-semibold text-slate-500 transition hover:text-primary" href="tel:+905398168013">
                   <span class="material-icons text-base">phone_in_talk</span>
                   <span>+90 539 816 80 13</span>
                 </a>
@@ -206,21 +214,29 @@
           </article>
 
           <article class="group flex flex-col overflow-hidden rounded-3xl bg-white shadow-xl ring-1 ring-slate-100 transition duration-300 hover:-translate-y-1 hover:shadow-2xl">
-            <figure class="relative h-52 overflow-hidden">
-              <img
-                class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-                src="https://images.unsplash.com/photo-1582719478148-dfdb1039670f?auto=format&amp;fit=crop&amp;w=800&amp;q=80"
-                alt="Kombi montajı yapan teknik ekip"
-              />
-              <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
-            </figure>
-            <div class="flex flex-1 flex-col p-6">
-              <h3 class="text-xl font-semibold text-slate-900">Kombi Montaj ve Petek Montajı</h3>
-              <p class="mt-3 text-sm leading-relaxed text-slate-600">
-                Standartlara uygun montaj uygulamalarıyla kombi ve peteklerinizin güvenli, verimli çalışmasını sağlıyoruz.
-              </p>
-              <div class="mt-6 border-t border-slate-200 pt-4">
-                <a class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-cyan-600" href="tel:+905398168013">
+            <a class="flex flex-1 flex-col" href="sutesisatitamirati.html">
+              <figure class="relative h-52 overflow-hidden">
+                <img
+                  class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                  src="https://images.unsplash.com/photo-1581579186989-4c04bf07ba1d?auto=format&amp;fit=crop&amp;w=800&amp;q=80"
+                  alt="Su tesisatı tamiratı yapan teknisyen"
+                />
+                <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
+              </figure>
+              <div class="flex flex-1 flex-col p-6">
+                <h3 class="text-xl font-semibold text-slate-900">Su Tesisatı Tamiratı</h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-600">
+                  Termal kamera ve akustik dinleme cihazlarıyla su kaçaklarını tespit edip kırmadan, dökmeden onarım yapıyoruz.
+                </p>
+              </div>
+            </a>
+            <div class="px-6 pb-6">
+              <div class="mt-6 flex items-center justify-between border-t border-slate-200 pt-4">
+                <a class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-cyan-600" href="sutesisatitamirati.html">
+                  <span class="material-icons text-base">arrow_forward</span>
+                  <span>Hizmeti İncele</span>
+                </a>
+                <a class="inline-flex items-center gap-2 text-sm font-semibold text-slate-500 transition hover:text-primary" href="tel:+905398168013">
                   <span class="material-icons text-base">phone_in_talk</span>
                   <span>+90 539 816 80 13</span>
                 </a>
@@ -229,44 +245,29 @@
           </article>
 
           <article class="group flex flex-col overflow-hidden rounded-3xl bg-white shadow-xl ring-1 ring-slate-100 transition duration-300 hover:-translate-y-1 hover:shadow-2xl">
-            <figure class="relative h-52 overflow-hidden">
-              <img
-                class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-                src="https://images.unsplash.com/photo-1581579186989-4c04bf07ba1d?auto=format&amp;fit=crop&amp;w=800&amp;q=80"
-                alt="Su tesisatı tamiratı yapan teknisyen"
-              />
-              <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
-            </figure>
-            <div class="flex flex-1 flex-col p-6">
-              <h3 class="text-xl font-semibold text-slate-900">Su Tesisatı Tamiratı</h3>
-              <p class="mt-3 text-sm leading-relaxed text-slate-600">
-                Termal kamera ve akustik dinleme cihazlarıyla su kaçaklarını tespit edip kırmadan, dökmeden onarım yapıyoruz.
-              </p>
-              <div class="mt-6 border-t border-slate-200 pt-4">
-                <a class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-cyan-600" href="tel:+905398168013">
-                  <span class="material-icons text-base">phone_in_talk</span>
-                  <span>+90 539 816 80 13</span>
-                </a>
+            <a class="flex flex-1 flex-col" href="sutesisatikurulumu.html">
+              <figure class="relative h-52 overflow-hidden">
+                <img
+                  class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                  src="https://images.unsplash.com/photo-1581092795360-fd1ca056c1bf?auto=format&amp;fit=crop&amp;w=800&amp;q=80"
+                  alt="Yeni su tesisatı kuran ekip"
+                />
+                <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
+              </figure>
+              <div class="flex flex-1 flex-col p-6">
+                <h3 class="text-xl font-semibold text-slate-900">Su Tesisatı Kurulumu</h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-600">
+                  Yeni inşaat ve tadilat projelerinde temiz su, atık su ve ısıtma hatlarını projeye uygun şekilde döşüyoruz.
+                </p>
               </div>
-            </div>
-          </article>
-
-          <article class="group flex flex-col overflow-hidden rounded-3xl bg-white shadow-xl ring-1 ring-slate-100 transition duration-300 hover:-translate-y-1 hover:shadow-2xl">
-            <figure class="relative h-52 overflow-hidden">
-              <img
-                class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-                src="https://images.unsplash.com/photo-1581092795360-fd1ca056c1bf?auto=format&amp;fit=crop&amp;w=800&amp;q=80"
-                alt="Yeni su tesisatı kuran ekip"
-              />
-              <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
-            </figure>
-            <div class="flex flex-1 flex-col p-6">
-              <h3 class="text-xl font-semibold text-slate-900">Su Tesisatı Kurulumu</h3>
-              <p class="mt-3 text-sm leading-relaxed text-slate-600">
-                Yeni inşaat ve tadilat projelerinde temiz su, atık su ve ısıtma hatlarını projeye uygun şekilde döşüyoruz.
-              </p>
-              <div class="mt-6 border-t border-slate-200 pt-4">
-                <a class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-cyan-600" href="tel:+905398168013">
+            </a>
+            <div class="px-6 pb-6">
+              <div class="mt-6 flex items-center justify-between border-t border-slate-200 pt-4">
+                <a class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-cyan-600" href="sutesisatikurulumu.html">
+                  <span class="material-icons text-base">arrow_forward</span>
+                  <span>Hizmeti İncele</span>
+                </a>
+                <a class="inline-flex items-center gap-2 text-sm font-semibold text-slate-500 transition hover:text-primary" href="tel:+905398168013">
                   <span class="material-icons text-base">phone_in_talk</span>
                   <span>+90 539 816 80 13</span>
                 </a>
@@ -329,7 +330,7 @@
           <div>
             <h4 class="text-lg font-semibold text-white">Hızlı Bağlantılar</h4>
             <ul class="mt-4 space-y-3 text-sm">
-              <li><a class="flex items-center gap-2 transition hover:text-white" href="#"><span class="material-icons text-base">chevron_right</span><span>Anasayfa</span></a></li>
+              <li><a class="flex items-center gap-2 transition hover:text-white" href="index.html"><span class="material-icons text-base">chevron_right</span><span>Anasayfa</span></a></li>
               <li><a class="flex items-center gap-2 transition hover:text-white" href="#"><span class="material-icons text-base">chevron_right</span><span>Kurumsal</span></a></li>
               <li><a class="flex items-center gap-2 transition hover:text-white" href="#hizmetler"><span class="material-icons text-base">chevron_right</span><span>Hizmetler</span></a></li>
               <li><a class="flex items-center gap-2 transition hover:text-white" href="#"><span class="material-icons text-base">chevron_right</span><span>S.S.S</span></a></li>
@@ -341,10 +342,9 @@
           <div>
             <h4 class="text-lg font-semibold text-white">Hizmetler</h4>
             <ul class="mt-4 space-y-3 text-sm">
-              <li><a class="flex items-center gap-2 transition hover:text-white" href="#hizmetler"><span class="material-icons text-base text-cyan-300">plumbing</span><span>Petek Temizliği</span></a></li>
-              <li><a class="flex items-center gap-2 transition hover:text-white" href="#hizmetler"><span class="material-icons text-base text-cyan-300">plumbing</span><span>Kombi Montaj ve Petek Montajı</span></a></li>
-              <li><a class="flex items-center gap-2 transition hover:text-white" href="#hizmetler"><span class="material-icons text-base text-cyan-300">build</span><span>Su Tesisatı Tamiratı</span></a></li>
-              <li><a class="flex items-center gap-2 transition hover:text-white" href="#hizmetler"><span class="material-icons text-base text-cyan-300">build_circle</span><span>Su Tesisatı Kurulumu</span></a></li>
+              <li><a class="flex items-center gap-2 transition hover:text-white" href="petektemizligi.html"><span class="material-icons text-base text-cyan-300">plumbing</span><span>Petek Temizliği</span></a></li>
+              <li><a class="flex items-center gap-2 transition hover:text-white" href="sutesisatitamirati.html"><span class="material-icons text-base text-cyan-300">build</span><span>Su Tesisatı Tamiratı</span></a></li>
+              <li><a class="flex items-center gap-2 transition hover:text-white" href="sutesisatikurulumu.html"><span class="material-icons text-base text-cyan-300">build_circle</span><span>Su Tesisatı Kurulumu</span></a></li>
             </ul>
           </div>
 
@@ -388,87 +388,4 @@
     </footer>
   </body>
 </html>
-=======
-<footer class="bg-[#0b1f4b] text-gray-300">
-  <div class="border-t border-white/10 bg-[#10275f]">
-    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
-      <div class="grid gap-10 lg:grid-cols-[1.2fr_1fr_1fr]">
-        <div>
-          <div class="flex items-center space-x-3">
-            <div class="bg-cyan-500/20 text-cyan-300 rounded-full p-3">
-              <span class="material-icons">water_drop</span>
-            </div>
-            <div>
-              <p class="text-sm uppercase tracking-[0.3em] text-cyan-300">D&amp;M Su Tesisatı</p>
-              <h3 class="text-2xl font-semibold text-white">Profesyonel Çözümler</h3>
-            </div>
-          </div>
-          <p class="mt-4 text-sm text-gray-400 leading-relaxed">
-            Deneyimli ekibimizle İstanbul'un tüm ilçelerinde su kaçağı tespiti, tesisat bakım ve onarım hizmetlerini
-            aynı gün içinde sağlıyoruz. Kırmadan, dökmeden kalıcı çözümler sunuyoruz.
-          </p>
-          <div class="mt-6 flex flex-wrap gap-4">
-            <a href="tel:05539729346" class="inline-flex items-center space-x-2 rounded-full bg-cyan-500 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-cyan-500/30 transition hover:bg-cyan-400">
-              <span class="material-icons text-base">call</span>
-              <span>Hemen Ara</span>
-            </a>
-            <a href="#iletisim" class="inline-flex items-center space-x-2 rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-gray-200 transition hover:border-cyan-400 hover:text-white">
-              <span class="material-icons text-base">chat</span>
-              <span>Teklif Al</span>
-            </a>
-          </div>
-        </div>
-        <div>
-          <h4 class="text-lg font-semibold text-white">Hızlı Bağlantılar</h4>
-          <ul class="mt-4 space-y-3 text-sm">
-            <li><a class="flex items-center space-x-2 transition hover:text-white" href="#"><span class="material-icons text-base">chevron_right</span><span>Anasayfa</span></a></li>
-            <li><a class="flex items-center space-x-2 transition hover:text-white" href="#"><span class="material-icons text-base">chevron_right</span><span>Kurumsal</span></a></li>
-            <li><a class="flex items-center space-x-2 transition hover:text-white" href="#"><span class="material-icons text-base">chevron_right</span><span>Hizmetler</span></a></li>
-            <li><a class="flex items-center space-x-2 transition hover:text-white" href="#"><span class="material-icons text-base">chevron_right</span><span>S.S.S</span></a></li>
-            <li><a class="flex items-center space-x-2 transition hover:text-white" href="#"><span class="material-icons text-base">chevron_right</span><span>Medya</span></a></li>
-            <li><a class="flex items-center space-x-2 transition hover:text-white" href="#iletisim"><span class="material-icons text-base">chevron_right</span><span>İletişim</span></a></li>
-          </ul>
-        </div>
-        <div>
-          <h4 class="text-lg font-semibold text-white">İletişim</h4>
-          <ul class="mt-4 space-y-4 text-sm">
-            <li class="flex items-start space-x-3">
-              <span class="material-icons text-base text-cyan-300">location_on</span>
-              <span>İstanbul Bağcılar Demirkapı Mahallesi<br/>1732 Sokak No:19/A</span>
-            </li>
-            <li class="flex items-start space-x-3">
-              <span class="material-icons text-base text-cyan-300">phone</span>
-              <span>0553 972 93 46</span>
-            </li>
-            <li class="flex items-start space-x-3">
-              <span class="material-icons text-base text-cyan-300">email</span>
-              <span>dmtesisat@gmail.com</span>
-            </li>
-            <li class="flex items-start space-x-3">
-              <span class="material-icons text-base text-cyan-300">schedule</span>
-              <span>7/24 acil destek hattı<br/>Planlı bakım için randevu alabilirsiniz.</span>
-            </li>
-          </ul>
-          <div class="mt-6 flex space-x-4">
-            <a class="hover:text-white" href="#" aria-label="Twitter"><svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M22.46 6c-.77.35-1.6.58-2.46.69a4.301 4.301 0 001.88-2.37 8.59 8.59 0 01-2.72 1.04 4.28 4.28 0 00-7.38 2.92c0 .34.04.67.11.98-3.56-.18-6.73-1.89-8.84-4.48a4.25 4.25 0 00-.58 2.15 4.28 4.28 0 001.91 3.56 4.23 4.23 0 01-1.94-.53v.05c0 2.08 1.49 3.82 3.45 4.21a4.33 4.33 0 01-1.93.07 4.29 4.29 0 004 2.97A8.6 8.6 0 012 19.54a12.13 12.13 0 006.56 1.92c7.87 0 12.18-6.52 12.18-12.18 0-.19 0-.38-.01-.57A8.57 8.57 0 0022.46 6z"/></svg></a>
-            <a class="hover:text-white" href="#" aria-label="Facebook"><svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12Z"/></svg></a>
-            <a class="hover:text-white" href="#" aria-label="Instagram"><svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.398 1.363.444 2.427.048 1.024.06 1.378.06 3.808s-.012 2.784-.06 3.808c-.046 1.064-.207 1.791-.444 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.398-2.427.444-1.024.048-1.378.06-3.808.06s-2.784-.012-3.808-.06c-1.064-.046-1.791-.207-2.427-.444a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.398-1.363-.444-2.427-.048-1.024-.06-1.378-.06-3.808s.012-2.784.06-3.808c.046-1.064.207-1.791.444-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 016.08 2.525c.636-.247 1.363-.398 2.427-.444C9.531 2.013 9.885 2 12.315 2zM12 7a5 5 0 100 10 5 5 0 000-10zm0 8a3 3 0 110-6 3 3 0 010 6zm6.406-11.845a1.25 1.25 0 100 2.5 1.25 1.25 0 000-2.5z"/></svg></a>
-            <a class="hover:text-white" href="#" aria-label="YouTube"><svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.812 5.418c.861.23 1.538.907 1.768 1.768C21.998 8.78 22 12 22 12s0 3.22-.42 4.814a2.502 2.502 0 01-1.768 1.768C18.219 19 12 19 12 19s-6.219 0-7.812-1.418a2.502 2.502 0 01-1.768-1.768C2 15.22 2 12 2 12s0-3.22.42-4.814a2.502 2.502 0 011.768-1.768C5.781 5 12 5 12 5s6.219 0 7.812.418ZM15.197 12 10 9v6l5.197-3z"/></svg></a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="border-t border-white/10 bg-[#0b1f4b]/90">
-    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-4 text-xs text-gray-400 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-      <p>&copy; 2024 D&amp;M Su Tesisatı. Tüm hakları saklıdır.</p>
-      <p class="flex items-center space-x-2">
-        <span class="material-icons text-base text-cyan-300">verified</span>
-        <span>Garantili onarım ve şeffaf fiyat politikası.</span>
-      </p>
-    </div>
-  </div>
-</footer>
-
-</body></html>
 

--- a/sutesisatikurulumu.html
+++ b/sutesisatikurulumu.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>D&M - Petek Temizliği Hizmeti</title>
+    <title>D&M - Su Tesisatı Kurulumu Hizmeti</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link
       rel="stylesheet"
@@ -93,19 +93,18 @@
           <div class="relative overflow-hidden rounded-3xl bg-slate-900/30">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://images.unsplash.com/photo-1581091226825-a6a2a5aee158?auto=format&amp;fit=crop&amp;w=1600&amp;q=80"
-              alt="Su tesisatı teknisyeni çalışma esnasında"
+              src="https://images.unsplash.com/photo-1581092795360-fd1ca056c1bf?auto=format&amp;fit=crop&amp;w=1600&amp;q=80"
+              alt="Su tesisatı montajı yapan ekip"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-[#0d1f4c]/90 via-[#0d1f4c]/80 to-[#143d7a]/70"></div>
             <div class="relative z-10 grid gap-10 px-6 py-16 md:grid-cols-[1.1fr_0.9fr] md:px-12 md:py-20">
               <div class="space-y-6 text-white">
-                <p class="text-sm font-semibold uppercase tracking-[0.5em] text-cyan-200">Profesyonel Destek</p>
+                <p class="text-sm font-semibold uppercase tracking-[0.5em] text-cyan-200">Anahtar Teslim Çözümler</p>
                 <h1 class="text-4xl font-bold leading-tight md:text-5xl">
-                  <span class="gradient-text">Su Kaçağı Tespiti</span> ve Tesisat Çözümleri
+                  <span class="gradient-text">Su Tesisatı Kurulumu</span> ile projeye tam uyum
                 </h1>
                 <p class="text-base text-blue-100 md:text-lg">
-                  Kırmadan dökmeden cihazla su kaçağı tespiti, petek temizliği ve kombi montajı hizmetlerimizle İstanbul
-                  genelinde aynı gün servis sağlıyoruz.
+                  Temiz su, atık su ve ısıtma hatlarını projeye uygun şekilde planlıyor, birinci sınıf malzemelerle uygulayarak uzun ömürlü ve verimli sistemler kuruyoruz.
                 </p>
                 <div class="flex flex-wrap items-center gap-4">
                   <a
@@ -129,23 +128,23 @@
                   <p class="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200">Neden Biz?</p>
                   <ul class="mt-3 space-y-2 text-sm leading-relaxed">
                     <li class="flex items-start gap-2">
+                      <span class="material-icons text-base text-cyan-300">architecture</span>
+                      <span>Proje okuma ve keşif ile tesisat güzergâhını doğru planlıyoruz</span>
+                    </li>
+                    <li class="flex items-start gap-2">
+                      <span class="material-icons text-base text-cyan-300">construction</span>
+                      <span>PEX, PPRC ve bakır borularda sertifikalı montaj ustaları</span>
+                    </li>
+                    <li class="flex items-start gap-2">
                       <span class="material-icons text-base text-cyan-300">verified</span>
-                      <span>Sertifikalı ve deneyimli ustalarla garantili çözümler</span>
-                    </li>
-                    <li class="flex items-start gap-2">
-                      <span class="material-icons text-base text-cyan-300">speed</span>
-                      <span>İstanbul genelinde aynı gün servis imkanı</span>
-                    </li>
-                    <li class="flex items-start gap-2">
-                      <span class="material-icons text-base text-cyan-300">precision_manufacturing</span>
-                      <span>Son teknoloji cihazlarla kırmadan su kaçağı tespiti</span>
+                      <span>Teslim öncesi basınç testi, izolasyon kontrolü ve garanti</span>
                     </li>
                   </ul>
                 </div>
                 <div class="rounded-2xl bg-white/10 p-6 text-white shadow-lg shadow-black/10 backdrop-blur">
                   <p class="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200">İletişim</p>
                   <p class="mt-3 text-lg font-semibold">+90 539 816 80 13</p>
-                  <p class="text-xs text-blue-100">7/24 Acil Destek Hattı</p>
+                  <p class="text-xs text-blue-100">7/24 Proje Desteği</p>
                 </div>
               </div>
             </div>
@@ -175,17 +174,13 @@
       <section class="container mx-auto px-4">
         <div class="grid overflow-hidden rounded-3xl bg-white shadow-2xl ring-1 ring-slate-100 md:grid-cols-[1.15fr_0.85fr]">
           <div class="space-y-6 p-8 md:p-12">
-            <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary">Petek Temizliği</p>
-            <h1 class="text-3xl font-bold text-slate-900 md:text-4xl">
-              Makineli petek temizliği ile maksimum ısınma performansı
-            </h1>
+            <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary">Su Tesisatı Kurulumu</p>
+            <h1 class="text-3xl font-bold text-slate-900 md:text-4xl">Yeni projeler için eksiksiz montaj ve devreye alma</h1>
             <p class="text-base leading-relaxed text-slate-600">
-              Kimyasal çözelti ve profesyonel makinelerle petek kanallarında biriken tortu ve çamuru temizleyerek suyun dolaşımını hızlandırıyoruz.
-              Böylece kombiniz daha az enerjiyle daha homojen ısı dağıtımı sağlar.
+              Konut, ofis ve ticari yapılarda temiz su, atık su ve ısıtma sistemleri için hattın geçtiği her noktayı projeye göre ölçüyor, montaj öncesi boru çapları ve kolektör noktalarını netleştiriyoruz. TSE belgeli malzemelerle uzun ömürlü tesisatlar kuruyoruz.
             </p>
             <p class="text-base leading-relaxed text-slate-600">
-              İstanbul'un tüm ilçelerinde aynı gün servisle hizmet veriyor, işlemi sonunda tesisatınızı temiz suyla durulayarak sisteme zarar vermeden teslim ediyoruz.
-              7/24 acil destek hattımızla kışa hazırlığı güvenle tamamlayın.
+              Zaman planına sadık kalarak kaba ve ince işlerin koordinasyonunu sağlıyor, montaj sonrasında hattı basınç ve kaçak testine tabi tutup devreye almadan önce kullanıcı eğitimini tamamlıyoruz.
             </p>
             <div class="flex flex-wrap items-center gap-4">
               <a
@@ -199,32 +194,32 @@
                 class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:border-cyan-500 hover:text-primary"
                 href="https://wa.me/905398168013"
               >
-                <span class="material-icons text-base">chat</span>
-                <span>WhatsApp</span>
+                <span class="material-icons text-base">chat_bubble</span>
+                <span>WhatsApp Destek</span>
               </a>
             </div>
           </div>
           <div class="relative h-full min-h-[320px]">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://images.unsplash.com/photo-1576602976046-88ac67a7ea6e?auto=format&amp;fit=crop&amp;w=900&amp;q=80"
-              alt="Petek temizliği işlemi"
+              src="https://images.unsplash.com/photo-1581093588401-22a57973f178?auto=format&amp;fit=crop&amp;w=900&amp;q=80"
+              alt="Yeni inşaatta su tesisatı kurulumu"
             />
             <div class="absolute inset-0 bg-gradient-to-t from-slate-900/70 via-slate-900/30 to-transparent"></div>
             <div class="absolute bottom-6 left-6 right-6 rounded-2xl bg-white/10 p-6 text-white shadow-lg backdrop-blur">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200">Hizmet Özeti</p>
               <ul class="mt-4 space-y-3 text-sm leading-relaxed text-blue-100">
                 <li class="flex items-start gap-2">
-                  <span class="material-icons text-base text-cyan-300">verified</span>
-                  <span>Kimyasal ilaçlama ve makineli sirkülasyonla etkili tortu temizliği</span>
+                  <span class="material-icons text-base text-cyan-300">map</span>
+                  <span>Projeye uygun güzergâh planı ve montaj öncesi keşif</span>
                 </li>
                 <li class="flex items-start gap-2">
-                  <span class="material-icons text-base text-cyan-300">speed</span>
-                  <span>Kombinizin daha hızlı ısınmasını sağlayan verim artışı</span>
+                  <span class="material-icons text-base text-cyan-300">home_repair_service</span>
+                  <span>Kaliteli malzemeyle kolektör, vana ve boru montajı</span>
                 </li>
                 <li class="flex items-start gap-2">
-                  <span class="material-icons text-base text-cyan-300">workspace_premium</span>
-                  <span>Deneyimli ustalarımızla garantili ve temiz teslimat</span>
+                  <span class="material-icons text-base text-cyan-300">science</span>
+                  <span>Basınç testi, izolasyon kontrolü ve devreye alma</span>
                 </li>
               </ul>
             </div>
@@ -234,40 +229,80 @@
 
       <section class="container mx-auto px-4 pt-20">
         <div class="mx-auto max-w-3xl text-center">
-          <h2 class="text-3xl font-bold text-slate-900 md:text-4xl">Profesyonel bakımla uzun ömürlü tesisat</h2>
+          <h2 class="text-3xl font-bold text-slate-900 md:text-4xl">Planlı iş programı ile sorunsuz teslim</h2>
           <p class="mt-4 text-base leading-relaxed text-slate-600">
-            Petek temizliği sonrası sistem basıncını ve su dengesini kontrol ederek kombinizin yıllık bakımını tamamlıyoruz.
-            Enerji faturalarınız düşerken, yaşam alanlarınızda eşit ısı dağılımının keyfini yaşarsınız.
+            Tadilat, yeni inşaat veya tesis yenilemesi fark etmeksizin inşaat programına uyum sağlar, diğer disiplinlerle koordineli çalışarak sürprizlere yer bırakmayan bir kurulum süreci sunarız.
           </p>
         </div>
         <div class="mt-12 grid gap-6 md:grid-cols-3">
           <article class="rounded-2xl bg-white p-6 shadow-lg shadow-slate-200/60 ring-1 ring-slate-100">
             <div class="flex items-center gap-3">
-              <span class="material-icons text-3xl text-cyan-500">water_drop</span>
-              <h3 class="text-lg font-semibold text-slate-900">Temiz sirkülasyon</h3>
+              <span class="material-icons text-3xl text-cyan-500">design_services</span>
+              <h3 class="text-lg font-semibold text-slate-900">Keşif &amp; Tasarım</h3>
             </div>
             <p class="mt-3 text-sm leading-relaxed text-slate-600">
-              Tesisatta dolaşan temiz su, radyatör kanallarının tıkanmasını engeller ve kombinin gereksiz zorlanmasını önler.
+              Mimari ve mekanik projeleri inceleyerek kullanım noktalarınızı doğru konumlandırıyor, tesisat planını sizinle paylaşıyoruz.
             </p>
           </article>
           <article class="rounded-2xl bg-white p-6 shadow-lg shadow-slate-200/60 ring-1 ring-slate-100">
             <div class="flex items-center gap-3">
-              <span class="material-icons text-3xl text-cyan-500">devices</span>
-              <h3 class="text-lg font-semibold text-slate-900">Uzman ekipman</h3>
+              <span class="material-icons text-3xl text-cyan-500">precision_manufacturing</span>
+              <h3 class="text-lg font-semibold text-slate-900">Profesyonel Montaj</h3>
             </div>
             <p class="mt-3 text-sm leading-relaxed text-slate-600">
-              Makineli temizlik sırasında kullanılan profesyonel cihazlar, döşemelerinize zarar vermeden tüm peteği tarar.
+              Kolon, kolektör, vana ve cihaz bağlantılarında standartlara uygun kaynak ve bağlantı teknikleri uyguluyoruz.
             </p>
           </article>
           <article class="rounded-2xl bg-white p-6 shadow-lg shadow-slate-200/60 ring-1 ring-slate-100">
             <div class="flex items-center gap-3">
-              <span class="material-icons text-3xl text-cyan-500">support_agent</span>
-              <h3 class="text-lg font-semibold text-slate-900">7/24 destek</h3>
+              <span class="material-icons text-3xl text-cyan-500">playlist_add_check</span>
+              <h3 class="text-lg font-semibold text-slate-900">Test &amp; Devreye Alma</h3>
             </div>
             <p class="mt-3 text-sm leading-relaxed text-slate-600">
-              Ustalarımız işlemin her adımını açıklayarak sorularınızı yanıtlar, servis sonrası kontrol çağrılarınızı takip eder.
+              Basınç testi, kaçak kontrolü ve tesisat temizliğini tamamlayarak sistemi sorunsuz şekilde devreye alıyoruz.
             </p>
           </article>
+        </div>
+      </section>
+
+      <section class="container mx-auto px-4 pt-20">
+        <div class="grid gap-10 rounded-3xl bg-white p-8 shadow-xl shadow-slate-200/60 ring-1 ring-slate-100 md:grid-cols-[1.1fr_0.9fr] md:p-12">
+          <div class="space-y-5">
+            <h2 class="text-3xl font-bold text-slate-900 md:text-4xl">Tüm süreç boyunca yanınızdayız</h2>
+            <ul class="space-y-4 text-sm leading-relaxed text-slate-600">
+              <li class="flex items-start gap-3">
+                <span class="material-icons mt-1 text-base text-cyan-500">event_note</span>
+                <span><strong>Program yönetimi:</strong> Şantiye iş takvimine göre planlama yaparak elektrik, alçıpan ve seramik ekipleriyle uyumlu çalışıyoruz.</span>
+              </li>
+              <li class="flex items-start gap-3">
+                <span class="material-icons mt-1 text-base text-cyan-500">inventory</span>
+                <span><strong>Malzeme tedariği:</strong> Onaylı markaların PPRC, PEX, bakır boru ve armatürlerini temin ederek tüm bileşenleri eksiksiz teslim ediyoruz.</span>
+              </li>
+              <li class="flex items-start gap-3">
+                <span class="material-icons mt-1 text-base text-cyan-500">support_agent</span>
+                <span><strong>Devreye alma desteği:</strong> Kullanıcı eğitimleri ve bakım önerileriyle tesisatınızı uzun yıllar sorunsuz kullanmanızı sağlıyoruz.</span>
+              </li>
+            </ul>
+          </div>
+          <div class="flex flex-col justify-between rounded-2xl bg-gradient-to-br from-primary via-blue-800 to-[#0c3d7a] p-8 text-white shadow-lg">
+            <div class="space-y-4">
+              <p class="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200">Projenizi Konuşalım</p>
+              <h3 class="text-2xl font-semibold md:text-3xl">Keşif randevusu için bize ulaşın</h3>
+              <p class="text-sm leading-relaxed text-blue-100">
+                Keşif uzmanlarımız ücretsiz yerinde inceleme ile ihtiyaçlarınızı belirler ve size özel teklifimizi sunar. İstanbul'un her noktasına kısa sürede ulaşırız.
+              </p>
+            </div>
+            <div class="mt-6 flex flex-col gap-3 text-sm font-semibold">
+              <a class="inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-primary transition hover:bg-blue-50" href="tel:+905398168013">
+                <span class="material-icons text-base">call</span>
+                <span>+90 539 816 80 13</span>
+              </a>
+              <a class="inline-flex items-center justify-center gap-2 rounded-full border border-white/60 px-6 py-3 text-white transition hover:border-white" href="https://wa.me/905398168013">
+                <span class="material-icons text-base">chat_bubble</span>
+                <span>WhatsApp Destek</span>
+              </a>
+            </div>
+          </div>
         </div>
       </section>
     </main>

--- a/sutesisatitamirati.html
+++ b/sutesisatitamirati.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>D&M - Petek Temizliği Hizmeti</title>
+    <title>D&M - Su Tesisatı Tamiratı Hizmeti</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link
       rel="stylesheet"
@@ -93,19 +93,19 @@
           <div class="relative overflow-hidden rounded-3xl bg-slate-900/30">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://images.unsplash.com/photo-1581091226825-a6a2a5aee158?auto=format&amp;fit=crop&amp;w=1600&amp;q=80"
-              alt="Su tesisatı teknisyeni çalışma esnasında"
+              src="https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&amp;fit=crop&amp;w=1600&amp;q=80"
+              alt="Su tesisatı kaçak tespiti yapan usta"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-[#0d1f4c]/90 via-[#0d1f4c]/80 to-[#143d7a]/70"></div>
             <div class="relative z-10 grid gap-10 px-6 py-16 md:grid-cols-[1.1fr_0.9fr] md:px-12 md:py-20">
               <div class="space-y-6 text-white">
                 <p class="text-sm font-semibold uppercase tracking-[0.5em] text-cyan-200">Profesyonel Destek</p>
                 <h1 class="text-4xl font-bold leading-tight md:text-5xl">
-                  <span class="gradient-text">Su Kaçağı Tespiti</span> ve Tesisat Çözümleri
+                  <span class="gradient-text">Su Tesisatı Tamiratı</span> ile kırmadan çözümler
                 </h1>
                 <p class="text-base text-blue-100 md:text-lg">
-                  Kırmadan dökmeden cihazla su kaçağı tespiti, petek temizliği ve kombi montajı hizmetlerimizle İstanbul
-                  genelinde aynı gün servis sağlıyoruz.
+                  Termal kamera, akustik dinleme ve nem ölçer cihazlarımızla su kaçaklarını noktasal olarak tespit ediyor,
+                  kırıp dökmeden aynı gün içerisinde kalıcı onarımlar gerçekleştiriyoruz.
                 </p>
                 <div class="flex flex-wrap items-center gap-4">
                   <a
@@ -129,16 +129,16 @@
                   <p class="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200">Neden Biz?</p>
                   <ul class="mt-3 space-y-2 text-sm leading-relaxed">
                     <li class="flex items-start gap-2">
-                      <span class="material-icons text-base text-cyan-300">verified</span>
-                      <span>Sertifikalı ve deneyimli ustalarla garantili çözümler</span>
-                    </li>
-                    <li class="flex items-start gap-2">
-                      <span class="material-icons text-base text-cyan-300">speed</span>
-                      <span>İstanbul genelinde aynı gün servis imkanı</span>
-                    </li>
-                    <li class="flex items-start gap-2">
                       <span class="material-icons text-base text-cyan-300">precision_manufacturing</span>
-                      <span>Son teknoloji cihazlarla kırmadan su kaçağı tespiti</span>
+                      <span>Termal kamera ve akustik dinleme ile kırmadan nokta atışı tespit</span>
+                    </li>
+                    <li class="flex items-start gap-2">
+                      <span class="material-icons text-base text-cyan-300">handyman</span>
+                      <span>Profesyonel ustalarla temiz, hızlı ve garantili onarım</span>
+                    </li>
+                    <li class="flex items-start gap-2">
+                      <span class="material-icons text-base text-cyan-300">verified</span>
+                      <span>Onarım sonrası basınç testi ve yazılı servis raporu</span>
                     </li>
                   </ul>
                 </div>
@@ -175,17 +175,13 @@
       <section class="container mx-auto px-4">
         <div class="grid overflow-hidden rounded-3xl bg-white shadow-2xl ring-1 ring-slate-100 md:grid-cols-[1.15fr_0.85fr]">
           <div class="space-y-6 p-8 md:p-12">
-            <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary">Petek Temizliği</p>
-            <h1 class="text-3xl font-bold text-slate-900 md:text-4xl">
-              Makineli petek temizliği ile maksimum ısınma performansı
-            </h1>
+            <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary">Su Tesisatı Tamiratı</p>
+            <h1 class="text-3xl font-bold text-slate-900 md:text-4xl">Kaçak tespitten boru değişimine anahtar teslim hizmet</h1>
             <p class="text-base leading-relaxed text-slate-600">
-              Kimyasal çözelti ve profesyonel makinelerle petek kanallarında biriken tortu ve çamuru temizleyerek suyun dolaşımını hızlandırıyoruz.
-              Böylece kombiniz daha az enerjiyle daha homojen ısı dağıtımı sağlar.
+              Gizli kaçaklara sahip temiz su ve pis su hatlarında titreşimli dinleme, termal kameralar ve nem ölçerlerle sorunun kaynağını dakikalar içinde ortaya çıkarıyoruz. Gereken durumlarda lokal kırımlar yaparak PPRC, galvaniz veya atık su borularınızı projeye uygun şekilde yeniliyoruz.
             </p>
             <p class="text-base leading-relaxed text-slate-600">
-              İstanbul'un tüm ilçelerinde aynı gün servisle hizmet veriyor, işlemi sonunda tesisatınızı temiz suyla durulayarak sisteme zarar vermeden teslim ediyoruz.
-              7/24 acil destek hattımızla kışa hazırlığı güvenle tamamlayın.
+              Çalışma alanını korumak için mobilya ve zeminleri koruyucu örtülerle kaplıyor, işlem sonrası bölgeyi temizleyip basınç testi uygulayarak sisteminizi güvenle teslim ediyoruz. Tüm onarımlarımız servis fişi ve garanti kapsamındadır.
             </p>
             <div class="flex flex-wrap items-center gap-4">
               <a
@@ -199,32 +195,32 @@
                 class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:border-cyan-500 hover:text-primary"
                 href="https://wa.me/905398168013"
               >
-                <span class="material-icons text-base">chat</span>
-                <span>WhatsApp</span>
+                <span class="material-icons text-base">chat_bubble</span>
+                <span>WhatsApp Destek</span>
               </a>
             </div>
           </div>
           <div class="relative h-full min-h-[320px]">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://images.unsplash.com/photo-1576602976046-88ac67a7ea6e?auto=format&amp;fit=crop&amp;w=900&amp;q=80"
-              alt="Petek temizliği işlemi"
+              src="https://images.unsplash.com/photo-1581579186989-4c04bf07ba1d?auto=format&amp;fit=crop&amp;w=900&amp;q=80"
+              alt="Kırmadan su kaçağı tamiri yapan ekip"
             />
             <div class="absolute inset-0 bg-gradient-to-t from-slate-900/70 via-slate-900/30 to-transparent"></div>
             <div class="absolute bottom-6 left-6 right-6 rounded-2xl bg-white/10 p-6 text-white shadow-lg backdrop-blur">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200">Hizmet Özeti</p>
               <ul class="mt-4 space-y-3 text-sm leading-relaxed text-blue-100">
                 <li class="flex items-start gap-2">
-                  <span class="material-icons text-base text-cyan-300">verified</span>
-                  <span>Kimyasal ilaçlama ve makineli sirkülasyonla etkili tortu temizliği</span>
+                  <span class="material-icons text-base text-cyan-300">travel_explore</span>
+                  <span>Termal kamera ve akustik dinleme ile dakikalar içinde sızıntı tespiti</span>
                 </li>
                 <li class="flex items-start gap-2">
-                  <span class="material-icons text-base text-cyan-300">speed</span>
-                  <span>Kombinizin daha hızlı ısınmasını sağlayan verim artışı</span>
+                  <span class="material-icons text-base text-cyan-300">build_circle</span>
+                  <span>Lokal kırma ve profesyonel kaynak ekipmanıyla kalıcı onarım</span>
                 </li>
                 <li class="flex items-start gap-2">
                   <span class="material-icons text-base text-cyan-300">workspace_premium</span>
-                  <span>Deneyimli ustalarımızla garantili ve temiz teslimat</span>
+                  <span>Basınç testi ve yazılı garanti ile güvence</span>
                 </li>
               </ul>
             </div>
@@ -234,40 +230,80 @@
 
       <section class="container mx-auto px-4 pt-20">
         <div class="mx-auto max-w-3xl text-center">
-          <h2 class="text-3xl font-bold text-slate-900 md:text-4xl">Profesyonel bakımla uzun ömürlü tesisat</h2>
+          <h2 class="text-3xl font-bold text-slate-900 md:text-4xl">Usta işçilikle güven veren çözümler</h2>
           <p class="mt-4 text-base leading-relaxed text-slate-600">
-            Petek temizliği sonrası sistem basıncını ve su dengesini kontrol ederek kombinizin yıllık bakımını tamamlıyoruz.
-            Enerji faturalarınız düşerken, yaşam alanlarınızda eşit ısı dağılımının keyfini yaşarsınız.
+            Su kaçağı, patlak boru veya tıkanmış atık su hattı fark etmeksizin uzman ekibimiz sorununuzun kök nedenini analiz eder, size ayrıntılı bilgi verir ve onayınız doğrultusunda şeffaf fiyatla müdahale eder.
           </p>
         </div>
         <div class="mt-12 grid gap-6 md:grid-cols-3">
           <article class="rounded-2xl bg-white p-6 shadow-lg shadow-slate-200/60 ring-1 ring-slate-100">
             <div class="flex items-center gap-3">
-              <span class="material-icons text-3xl text-cyan-500">water_drop</span>
-              <h3 class="text-lg font-semibold text-slate-900">Temiz sirkülasyon</h3>
+              <span class="material-icons text-3xl text-cyan-500">plumbing</span>
+              <h3 class="text-lg font-semibold text-slate-900">Gelişmiş diagnostik</h3>
             </div>
             <p class="mt-3 text-sm leading-relaxed text-slate-600">
-              Tesisatta dolaşan temiz su, radyatör kanallarının tıkanmasını engeller ve kombinin gereksiz zorlanmasını önler.
+              Tüm tesisat hatlarını kamera, termal ve akustik cihazlarla tarayarak sorunun kaynağını noktasal olarak belirliyoruz.
             </p>
           </article>
           <article class="rounded-2xl bg-white p-6 shadow-lg shadow-slate-200/60 ring-1 ring-slate-100">
             <div class="flex items-center gap-3">
-              <span class="material-icons text-3xl text-cyan-500">devices</span>
-              <h3 class="text-lg font-semibold text-slate-900">Uzman ekipman</h3>
+              <span class="material-icons text-3xl text-cyan-500">cleaning_services</span>
+              <h3 class="text-lg font-semibold text-slate-900">Temiz çalışma</h3>
             </div>
             <p class="mt-3 text-sm leading-relaxed text-slate-600">
-              Makineli temizlik sırasında kullanılan profesyonel cihazlar, döşemelerinize zarar vermeden tüm peteği tarar.
+              Koruyucu kaplamalar, tozsuz kesim ve profesyonel temizlikle yaşam alanınıza minimum müdahalede bulunuyoruz.
             </p>
           </article>
           <article class="rounded-2xl bg-white p-6 shadow-lg shadow-slate-200/60 ring-1 ring-slate-100">
             <div class="flex items-center gap-3">
-              <span class="material-icons text-3xl text-cyan-500">support_agent</span>
-              <h3 class="text-lg font-semibold text-slate-900">7/24 destek</h3>
+              <span class="material-icons text-3xl text-cyan-500">summarize</span>
+              <h3 class="text-lg font-semibold text-slate-900">Şeffaf raporlama</h3>
             </div>
             <p class="mt-3 text-sm leading-relaxed text-slate-600">
-              Ustalarımız işlemin her adımını açıklayarak sorularınızı yanıtlar, servis sonrası kontrol çağrılarınızı takip eder.
+              Müdahale öncesi ve sonrası fotoğraflı rapor, kullanılan malzeme ve garanti bilgilerini sizinle paylaşıyoruz.
             </p>
           </article>
+        </div>
+      </section>
+
+      <section class="container mx-auto px-4 pt-20">
+        <div class="grid gap-10 rounded-3xl bg-white p-8 shadow-xl shadow-slate-200/60 ring-1 ring-slate-100 md:grid-cols-[1.1fr_0.9fr] md:p-12">
+          <div class="space-y-5">
+            <h2 class="text-3xl font-bold text-slate-900 md:text-4xl">Üç adımda su tesisatı onarımı</h2>
+            <ul class="space-y-4 text-sm leading-relaxed text-slate-600">
+              <li class="flex items-start gap-3">
+                <span class="material-icons mt-1 text-base text-cyan-500">looks_one</span>
+                <span><strong>Keşif &amp; Tespit:</strong> Yerinde ücretsiz keşif yaparak arızanın noktasını cihazlarımızla belirliyor, müdahale planını paylaşıyoruz.</span>
+              </li>
+              <li class="flex items-start gap-3">
+                <span class="material-icons mt-1 text-base text-cyan-500">looks_two</span>
+                <span><strong>Onarım &amp; Yenileme:</strong> Gerekli parça değişimlerini orijinal malzemelerle gerçekleştirip sızıntıyı tamamen ortadan kaldırıyoruz.</span>
+              </li>
+              <li class="flex items-start gap-3">
+                <span class="material-icons mt-1 text-base text-cyan-500">looks_3</span>
+                <span><strong>Test &amp; Teslim:</strong> Basınç testi, izolasyon kontrolü ve temizlik sonrası hattı tekrar devreye alarak garantili şekilde teslim ediyoruz.</span>
+              </li>
+            </ul>
+          </div>
+          <div class="flex flex-col justify-between rounded-2xl bg-gradient-to-br from-primary via-blue-800 to-[#0c3d7a] p-8 text-white shadow-lg">
+            <div class="space-y-4">
+              <p class="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200">7/24 Ulaşın</p>
+              <h3 class="text-2xl font-semibold md:text-3xl">Acil su kaçağı için hemen arayın</h3>
+              <p class="text-sm leading-relaxed text-blue-100">
+                Gecikmeden müdahale edilen su kaçakları evinize ve komşularınıza vereceği zararı en aza indirir. Mobil ekiplerimiz tüm İstanbul'da aynı gün çözümler sunar.
+              </p>
+            </div>
+            <div class="mt-6 flex flex-col gap-3 text-sm font-semibold">
+              <a class="inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-primary transition hover:bg-blue-50" href="tel:+905398168013">
+                <span class="material-icons text-base">call</span>
+                <span>+90 539 816 80 13</span>
+              </a>
+              <a class="inline-flex items-center justify-center gap-2 rounded-full border border-white/60 px-6 py-3 text-white transition hover:border-white" href="https://wa.me/905398168013">
+                <span class="material-icons text-base">chat_bubble</span>
+                <span>WhatsApp Destek</span>
+              </a>
+            </div>
+          </div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- update the homepage navigation and service cards to link directly to the dedicated service detail pages while keeping phone CTAs
- adjust the homepage grid to the three available services and add detail/phone actions inside each card
- align the service lists in the homepage and detail page footers so they point to the actual service documents instead of placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce95c9ec7083259b8049782627f185