### PR TITLE
Encode ampersands in kombipetekmontaj HTML

### DIFF
--- a/kombipetekmontaj.html
+++ b/kombipetekmontaj.html
@@ -4,11 +4,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>D&M - Kombi Petek Montajı Hizmeti</title>
+    <title>D&amp;M - Kombi Petek Montajı Hizmeti</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&amp;display=swap"
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <script>
@@ -71,7 +71,7 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&M</a>
+          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>
@@ -94,7 +94,7 @@
           <div class="relative overflow-hidden rounded-3xl bg-slate-900/30">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://images.unsplash.com/photo-1585421514738-01798e348b17?auto=format&fit=crop&w=1600&q=80"
+              src="https://images.unsplash.com/photo-1585421514738-01798e348b17?auto=format&amp;fit=crop&amp;w=1600&amp;q=80"
               alt="Kombi montajı gerçekleştiren uzman"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-[#0d1f4c]/90 via-[#0d1f4c]/80 to-[#143d7a]/70"></div>
@@ -203,7 +203,7 @@
           <div class="relative h-full min-h-[320px]">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://images.unsplash.com/photo-1616628188505-404cb3cdcea4?auto=format&fit=crop&w=900&q=80"
+              src="https://images.unsplash.com/photo-1616628188505-404cb3cdcea4?auto=format&amp;fit=crop&amp;w=900&amp;q=80"
               alt="Petek montajı yapılan daire"
             />
             <div class="absolute inset-0 bg-gradient-to-t from-slate-900/70 via-slate-900/30 to-transparent"></div>
@@ -317,7 +317,7 @@
                 <span class="material-icons">water_drop</span>
               </div>
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-cyan-300">D&M Su Tesisatı</p>
+                <p class="text-xs uppercase tracking-[0.3em] text-cyan-300">D&amp;M Su Tesisatı</p>
                 <h3 class="text-2xl font-semibold text-white">Profesyonel Çözümler</h3>
               </div>
             </div>
@@ -388,7 +388,7 @@
       </div>
       <div class="border-t border-white/10 bg-[#091836]">
         <div class="container mx-auto flex flex-col gap-2 px-4 py-4 text-xs text-slate-300 md:flex-row md:items-center md:justify-between">
-          <p>&copy; 2024 D&M Su Tesisatı. Tüm hakları saklıdır.</p>
+          <p>&copy; 2024 D&amp;M Su Tesisatı. Tüm hakları saklıdır.</p>
           <p class="flex items-center gap-2">
             <span class="material-icons text-base text-cyan-300">verified</span>
             <span>Garantili onarım ve şeffaf fiyat politikası.</span>
@@ -398,6 +398,3 @@
     </footer>
   </body>
 </html>
-=======
-
-

--- a/petektemizligi.html
+++ b/petektemizligi.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>D&M - Petek Temizliği Hizmeti</title>
+    <title>D&amp;M - Petek Temizliği Hizmeti</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link
       rel="stylesheet"
@@ -70,7 +70,7 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&M</a>
+          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>
@@ -281,7 +281,7 @@
                 <span class="material-icons">water_drop</span>
               </div>
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-cyan-300">D&M Su Tesisatı</p>
+                <p class="text-xs uppercase tracking-[0.3em] text-cyan-300">D&amp;M Su Tesisatı</p>
                 <h3 class="text-2xl font-semibold text-white">Profesyonel Çözümler</h3>
               </div>
             </div>
@@ -361,7 +361,7 @@
       </div>
       <div class="border-t border-white/10 bg-[#091836]">
         <div class="container mx-auto flex flex-col gap-2 px-4 py-4 text-xs text-slate-300 md:flex-row md:items-center md:justify-between">
-          <p>&copy; 2024 D&M Su Tesisatı. Tüm hakları saklıdır.</p>
+          <p>&copy; 2024 D&amp;M Su Tesisatı. Tüm hakları saklıdır.</p>
           <p class="flex items-center gap-2">
             <span class="material-icons text-base text-cyan-300">verified</span>
             <span>Garantili onarım ve şeffaf fiyat politikası.</span>

--- a/sutesisatikurulumu.html
+++ b/sutesisatikurulumu.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>D&M - Su Tesisatı Kurulumu Hizmeti</title>
+    <title>D&amp;M - Su Tesisatı Kurulumu Hizmeti</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link
       rel="stylesheet"
@@ -70,7 +70,7 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&M</a>
+          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>
@@ -316,7 +316,7 @@
                 <span class="material-icons">water_drop</span>
               </div>
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-cyan-300">D&M Su Tesisatı</p>
+                <p class="text-xs uppercase tracking-[0.3em] text-cyan-300">D&amp;M Su Tesisatı</p>
                 <h3 class="text-2xl font-semibold text-white">Profesyonel Çözümler</h3>
               </div>
             </div>
@@ -396,7 +396,7 @@
       </div>
       <div class="border-t border-white/10 bg-[#091836]">
         <div class="container mx-auto flex flex-col gap-2 px-4 py-4 text-xs text-slate-300 md:flex-row md:items-center md:justify-between">
-          <p>&copy; 2024 D&M Su Tesisatı. Tüm hakları saklıdır.</p>
+          <p>&copy; 2024 D&amp;M Su Tesisatı. Tüm hakları saklıdır.</p>
           <p class="flex items-center gap-2">
             <span class="material-icons text-base text-cyan-300">verified</span>
             <span>Garantili onarım ve şeffaf fiyat politikası.</span>

--- a/sutesisatitamirati.html
+++ b/sutesisatitamirati.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>D&M - Su Tesisatı Tamiratı Hizmeti</title>
+    <title>D&amp;M - Su Tesisatı Tamiratı Hizmeti</title>
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link
       rel="stylesheet"
@@ -70,7 +70,7 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&M</a>
+          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>
@@ -317,7 +317,7 @@
                 <span class="material-icons">water_drop</span>
               </div>
               <div>
-                <p class="text-xs uppercase tracking-[0.3em] text-cyan-300">D&M Su Tesisatı</p>
+                <p class="text-xs uppercase tracking-[0.3em] text-cyan-300">D&amp;M Su Tesisatı</p>
                 <h3 class="text-2xl font-semibold text-white">Profesyonel Çözümler</h3>
               </div>
             </div>
@@ -397,7 +397,7 @@
       </div>
       <div class="border-t border-white/10 bg-[#091836]">
         <div class="container mx-auto flex flex-col gap-2 px-4 py-4 text-xs text-slate-300 md:flex-row md:items-center md:justify-between">
-          <p>&copy; 2024 D&M Su Tesisatı. Tüm hakları saklıdır.</p>
+          <p>&copy; 2024 D&amp;M Su Tesisatı. Tüm hakları saklıdır.</p>
           <p class="flex items-center gap-2">
             <span class="material-icons text-base text-cyan-300">verified</span>
             <span>Garantili onarım ve şeffaf fiyat politikası.</span>


### PR DESCRIPTION
## Summary
- encode ampersands in the Google Fonts stylesheet link and Unsplash image URLs on kombipetekmontaj.html to maintain valid HTML markup
- escape the D&M brand text across kombipetekmontaj, petektemizligi, sutesisatikurulumu and sutesisatitamirati pages and remove the stray merge marker so the markup validates cleanly

## Testing
- `npx htmlhint *.html` *(fails: 403 Forbidden when downloading package)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb98819308325afbd4e673d995ed1