### PR TITLE
Add D&M logo to site header

### DIFF
--- a/assets/dm-logo.svg
+++ b/assets/dm-logo.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">D&amp;M Tesisat Logosu</title>
+  <desc id="desc">Mavi daire içerisinde musluk ve anahtar ikonları ile D&amp;M Tesisat yazısı</desc>
+  <circle cx="256" cy="256" r="240" fill="#1e75bc" />
+  <g fill="#ffffff">
+    <path d="M186 128h140v40h-40v30h-60v-30h-40z" />
+    <path d="M128 236h152v-32h-22c-24.3 0-44-19.7-44-44v-20h46v18c0 11 9 20 20 20h88c11 0 20-9 20-20v-18h46v20c0 24.3-19.7 44-44 44h-22v32h74c37.5 0 68 30.5 68 68v48h-96c-17.7 0-32 14.3-32 32v36h-108v-36c0-17.7-14.3-32-32-32h-82z" />
+  </g>
+  <path d="M220 332c0 26-32 56-32 56s-32-30-32-56c0-20 14.3-34 32-34s32 14 32 34z" fill="#ffffff" />
+  <g fill="#ffffff" transform="translate(256 320)">
+    <g transform="rotate(-32)">
+      <rect x="-20" y="-96" width="40" height="192" rx="20" />
+      <path d="M0 -132c24 0 44 20 44 44c0 12-12 30-12 30h-64s-12-18-12-30c0-24 20-44 44-44z" />
+      <rect x="-48" y="64" width="96" height="32" rx="16" />
+    </g>
+    <g transform="rotate(34)">
+      <rect x="-16" y="-108" width="32" height="216" rx="16" />
+      <circle cx="0" cy="-128" r="28" />
+      <path d="M0 -160c26 0 48 22 48 48c0 10-6 22-6 22h-84c0-12-6-22-6-22c0-26 22-48 48-48z" />
+      <rect x="-44" y="76" width="88" height="32" rx="16" />
+    </g>
+  </g>
+  <text x="256" y="432" text-anchor="middle" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" font-weight="700" font-size="64" fill="#ffffff" letter-spacing="6">
+    D&amp;M TESISAT
+  </text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,14 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
+          <a class="flex items-start gap-3 text-3xl font-semibold tracking-wide text-white" href="index.html">
+            <img
+              src="assets/dm-logo.svg"
+              alt="D&amp;M Tesisat logosu"
+              class="h-14 w-14 -mt-2 drop-shadow-lg"
+            />
+            <span class="leading-tight">D&amp;M</span>
+          </a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>

--- a/kombipetekmontaj.html
+++ b/kombipetekmontaj.html
@@ -71,7 +71,14 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
+          <a class="flex items-start gap-3 text-3xl font-semibold tracking-wide text-white" href="index.html">
+            <img
+              src="assets/dm-logo.svg"
+              alt="D&amp;M Tesisat logosu"
+              class="h-14 w-14 -mt-2 drop-shadow-lg"
+            />
+            <span class="leading-tight">D&amp;M</span>
+          </a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>

--- a/petektemizligi.html
+++ b/petektemizligi.html
@@ -70,7 +70,14 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
+          <a class="flex items-start gap-3 text-3xl font-semibold tracking-wide text-white" href="index.html">
+            <img
+              src="assets/dm-logo.svg"
+              alt="D&amp;M Tesisat logosu"
+              class="h-14 w-14 -mt-2 drop-shadow-lg"
+            />
+            <span class="leading-tight">D&amp;M</span>
+          </a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>

--- a/sutesisatikurulumu.html
+++ b/sutesisatikurulumu.html
@@ -70,7 +70,14 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
+          <a class="flex items-start gap-3 text-3xl font-semibold tracking-wide text-white" href="index.html">
+            <img
+              src="assets/dm-logo.svg"
+              alt="D&amp;M Tesisat logosu"
+              class="h-14 w-14 -mt-2 drop-shadow-lg"
+            />
+            <span class="leading-tight">D&amp;M</span>
+          </a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>

--- a/sutesisatitamirati.html
+++ b/sutesisatitamirati.html
@@ -70,7 +70,14 @@
       </div>
       <header class="pb-16">
         <div class="container mx-auto flex flex-wrap items-center justify-between gap-6 px-4 py-6">
-          <a class="text-3xl font-semibold tracking-wide text-white" href="index.html">D&amp;M</a>
+          <a class="flex items-start gap-3 text-3xl font-semibold tracking-wide text-white" href="index.html">
+            <img
+              src="assets/dm-logo.svg"
+              alt="D&amp;M Tesisat logosu"
+              class="h-14 w-14 -mt-2 drop-shadow-lg"
+            />
+            <span class="leading-tight">D&amp;M</span>
+          </a>
           <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
             <a class="border-b-2 border-cyan-400 pb-1 text-white" href="index.html">Anasayfa</a>
             <a class="hover:text-white/80" href="#">Kurumsal</a>


### PR DESCRIPTION
## Summary
- add a reusable vector version of the D&M Tesisat logo
- surface the new logo next to the brand name in the header on all main pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced5c59ee883259235f92b6a0b255a