### PR TITLE
Replace local PNG art with inline SVG illustrations

### DIFF
--- a/assets/kombi-petek-montaj-illustration.svg
+++ b/assets/kombi-petek-montaj-illustration.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1067" role="img" aria-labelledby="title desc">
+  <title id="title">Kombi ve petek montajı illüstrasyonu</title>
+  <desc id="desc">Kombi ve radyatör montajını temsil eden borular, göstergeler ve sıcaklık simgeleri.</desc>
+  <defs>
+    <linearGradient id="kombi-bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#13253f" />
+      <stop offset="60%" stop-color="#163d63" />
+      <stop offset="100%" stop-color="#1e4d7f" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#d9e7ff" stop-opacity="0.9" />
+    </linearGradient>
+    <linearGradient id="pipe-warm" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ff8a65" />
+      <stop offset="100%" stop-color="#ffbe76" />
+    </linearGradient>
+    <linearGradient id="pipe-cool" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#4facfe" />
+      <stop offset="100%" stop-color="#00f2fe" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1067" fill="url(#kombi-bg)" />
+  <g opacity="0.4">
+    <rect x="0" y="640" width="1600" height="200" fill="#0d1729" />
+    <rect x="0" y="840" width="1600" height="120" fill="#08101f" />
+  </g>
+  <g transform="translate(240 240)">
+    <rect x="0" y="0" width="780" height="540" rx="60" fill="#0f1d33" opacity="0.7" />
+    <rect x="64" y="64" width="652" height="412" rx="46" fill="url(#panel)" />
+    <g transform="translate(120 120)" fill="#1e4d7f" opacity="0.35">
+      <rect x="0" y="0" width="520" height="28" rx="14" />
+      <rect x="0" y="60" width="520" height="28" rx="14" />
+      <rect x="0" y="120" width="520" height="28" rx="14" />
+      <rect x="0" y="180" width="520" height="28" rx="14" />
+      <rect x="0" y="240" width="520" height="28" rx="14" />
+    </g>
+    <g transform="translate(120 120)">
+      <rect x="0" y="0" width="84" height="300" rx="30" fill="#e6eefc" stroke="#b3c6e5" stroke-width="6" />
+      <rect x="140" y="0" width="84" height="300" rx="30" fill="#e6eefc" stroke="#b3c6e5" stroke-width="6" />
+      <rect x="280" y="0" width="84" height="300" rx="30" fill="#e6eefc" stroke="#b3c6e5" stroke-width="6" />
+      <rect x="420" y="0" width="84" height="300" rx="30" fill="#e6eefc" stroke="#b3c6e5" stroke-width="6" />
+    </g>
+    <g transform="translate(120 440)" fill="none" stroke-width="18" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M0 0h520" stroke="url(#pipe-warm)" />
+      <path d="M520 0c80 0 140 40 200 120" stroke="url(#pipe-warm)" />
+      <path d="M0 60h520" stroke="url(#pipe-cool)" />
+      <path d="M520 60c90 0 150 30 210 110" stroke="url(#pipe-cool)" />
+    </g>
+  </g>
+  <g transform="translate(1040 320)">
+    <rect x="0" y="0" width="280" height="420" rx="46" fill="url(#panel)" />
+    <rect x="34" y="48" width="212" height="150" rx="30" fill="#122c4c" />
+    <g transform="translate(80 84)">
+      <circle cx="0" cy="0" r="30" fill="#ff8a65" opacity="0.9" />
+      <circle cx="62" cy="0" r="30" fill="#4facfe" opacity="0.9" />
+      <circle cx="31" cy="62" r="22" fill="#c8d9ff" opacity="0.8" />
+    </g>
+    <g transform="translate(46 240)" fill="none" stroke-linecap="round" stroke-width="16">
+      <path d="M0 60c34-40 68-60 112-60 44 0 78 20 112 60" stroke="#ffb86c" />
+      <path d="M0 120c34 42 68 62 112 62 44 0 78-20 112-62" stroke="#4dd0ff" />
+    </g>
+    <rect x="72" y="332" width="136" height="48" rx="24" fill="#122c4c" />
+    <rect x="98" y="346" width="84" height="20" rx="10" fill="#ffffff" opacity="0.8" />
+  </g>
+  <g opacity="0.35" fill="#4dd0ff">
+    <circle cx="1180" cy="260" r="34" />
+    <circle cx="1260" cy="220" r="20" />
+    <circle cx="1340" cy="300" r="26" />
+    <circle cx="1420" cy="240" r="18" />
+    <circle cx="1500" cy="320" r="24" />
+  </g>
+  <g opacity="0.3" fill="#ffaf82">
+    <circle cx="360" cy="220" r="28" />
+    <circle cx="440" cy="180" r="18" />
+    <circle cx="520" cy="210" r="22" />
+    <circle cx="600" cy="170" r="16" />
+  </g>
+</svg>

--- a/assets/petek-temizligi-illustration.svg
+++ b/assets/petek-temizligi-illustration.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1067" role="img" aria-labelledby="title desc">
+  <title id="title">Petek temizliği illüstrasyonu</title>
+  <desc id="desc">Petek temizleme makinesi ve radyatör yüzeyini soyut şekilde gösteren illüstrasyon.</desc>
+  <defs>
+    <linearGradient id="petek-bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1d2b64" />
+      <stop offset="60%" stop-color="#283c86" />
+      <stop offset="100%" stop-color="#2f80ed" />
+    </linearGradient>
+    <linearGradient id="petek-bars" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fff7d6" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#ffd89b" stop-opacity="0.75" />
+    </linearGradient>
+    <linearGradient id="machine" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fafcff" />
+      <stop offset="100%" stop-color="#c8d9ff" />
+    </linearGradient>
+    <linearGradient id="hose" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#34a0ff" />
+      <stop offset="100%" stop-color="#4be4ff" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1067" fill="url(#petek-bg)" />
+  <g opacity="0.45">
+    <rect x="0" y="620" width="1600" height="180" fill="#101c3a" />
+    <rect x="0" y="800" width="1600" height="120" fill="#0c1327" />
+  </g>
+  <g transform="translate(240 240)">
+    <rect x="0" y="0" width="760" height="540" rx="60" fill="#101c3a" opacity="0.7" />
+    <rect x="60" y="60" width="640" height="420" rx="46" fill="#182956" stroke="#3c5aa9" stroke-width="12" />
+    <g transform="translate(120 120)" fill="url(#petek-bars)" stroke="#fbd079" stroke-width="6" stroke-linejoin="round">
+      <rect x="0" y="0" width="70" height="300" rx="26" />
+      <rect x="120" y="0" width="70" height="300" rx="26" />
+      <rect x="240" y="0" width="70" height="300" rx="26" />
+      <rect x="360" y="0" width="70" height="300" rx="26" />
+      <rect x="480" y="0" width="70" height="300" rx="26" />
+    </g>
+    <g transform="translate(90 110)" stroke="#fbd079" stroke-width="6" stroke-linecap="round" opacity="0.6">
+      <path d="M0 0h580" />
+      <path d="M0 50h580" />
+      <path d="M0 100h580" />
+      <path d="M0 150h580" />
+      <path d="M0 200h580" />
+      <path d="M0 250h580" />
+    </g>
+  </g>
+  <g transform="translate(1020 390)">
+    <rect x="0" y="0" width="320" height="240" rx="40" fill="url(#machine)" />
+    <rect x="36" y="40" width="248" height="90" rx="24" fill="#1b2c58" />
+    <circle cx="96" cy="86" r="26" fill="#ff6b6b" opacity="0.8" />
+    <circle cx="172" cy="86" r="26" fill="#51eaea" opacity="0.8" />
+    <rect x="118" y="156" width="84" height="40" rx="20" fill="#1b2c58" />
+    <rect x="130" y="166" width="60" height="20" rx="10" fill="#c8d9ff" />
+  </g>
+  <path d="M1150 480c120 40 190 120 260 160" fill="none" stroke="url(#hose)" stroke-width="20" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+  <path d="M1390 640c40-60 72-100 130-120" fill="none" stroke="#4be4ff" stroke-width="16" stroke-linecap="round" opacity="0.6" />
+  <g opacity="0.35" fill="#51eaea">
+    <circle cx="1180" cy="340" r="28" />
+    <circle cx="1260" cy="320" r="18" />
+    <circle cx="1340" cy="360" r="24" />
+    <circle cx="1420" cy="300" r="16" />
+  </g>
+  <g opacity="0.4" fill="#ffe29f">
+    <circle cx="360" cy="190" r="32" />
+    <circle cx="480" cy="160" r="20" />
+    <circle cx="600" cy="180" r="26" />
+    <circle cx="720" cy="150" r="18" />
+  </g>
+</svg>

--- a/assets/su-kacagi-illustration.svg
+++ b/assets/su-kacagi-illustration.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1067" role="img" aria-labelledby="title desc">
+  <title id="title">Su kaçağı tespiti illüstrasyonu</title>
+  <desc id="desc">Sensörlerle boru hattındaki su kaçaklarını kontrol eden teknisyeni betimleyen soyut çizim.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0b2b60" />
+      <stop offset="60%" stop-color="#0e4a92" />
+      <stop offset="100%" stop-color="#0a2b6f" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#44d2ff" stop-opacity="0.55" />
+      <stop offset="60%" stop-color="#1a7ad8" stop-opacity="0.15" />
+      <stop offset="100%" stop-color="#0b2b60" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="pipe" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#7ac5ff" />
+      <stop offset="100%" stop-color="#3a8cd9" />
+    </linearGradient>
+    <linearGradient id="device" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#8fd2ff" stop-opacity="0.9" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1067" fill="url(#bg)" />
+  <rect width="1600" height="1067" fill="url(#glow)" />
+  <g fill="#0c366d" opacity="0.45">
+    <path d="M0 780h1600v120H0z" />
+    <path d="M0 900h1600v80H0z" />
+  </g>
+  <g fill="none" stroke="#103e7c" stroke-width="16" opacity="0.35">
+    <path d="M180 360h1240v120H180z" />
+    <path d="M320 540h960v120H320z" />
+    <path d="M460 720h680v100H460z" />
+  </g>
+  <g fill="url(#pipe)" stroke="#a8ddff" stroke-width="6" stroke-linejoin="round">
+    <rect x="300" y="320" width="60" height="420" rx="20" />
+    <rect x="420" y="420" width="760" height="70" rx="35" />
+    <rect x="1180" y="260" width="70" height="520" rx="25" />
+  </g>
+  <g opacity="0.5" stroke="#4ed4ff" stroke-width="10" stroke-linecap="round">
+    <path d="M470 456h220" />
+    <path d="M470 486h220" />
+    <path d="M470 516h220" />
+  </g>
+  <g transform="translate(940 360)">
+    <rect x="0" y="0" width="280" height="220" rx="32" fill="url(#device)" />
+    <rect x="34" y="36" width="212" height="92" rx="18" fill="#0f3f83" />
+    <circle cx="84" cy="82" r="22" fill="#12d0ff" opacity="0.7" />
+    <circle cx="142" cy="82" r="22" fill="#12d0ff" opacity="0.5" />
+    <rect x="74" y="148" width="132" height="28" rx="14" fill="#0f3f83" />
+    <rect x="104" y="152" width="72" height="20" rx="10" fill="#ffffff" opacity="0.7" />
+  </g>
+  <g transform="translate(1050 430)">
+    <circle cx="180" cy="200" r="120" fill="none" stroke="#54d8ff" stroke-width="14" opacity="0.5" />
+    <circle cx="180" cy="200" r="170" fill="none" stroke="#8be9ff" stroke-width="10" stroke-dasharray="40 24" opacity="0.4" />
+    <circle cx="180" cy="200" r="210" fill="none" stroke="#48b6ff" stroke-width="8" stroke-dasharray="20 18" opacity="0.3" />
+    <g transform="translate(140 160)">
+      <rect x="0" y="0" width="80" height="110" rx="20" fill="#112a52" opacity="0.9" />
+      <rect x="12" y="16" width="56" height="50" rx="10" fill="#1e5ea8" />
+      <circle cx="40" cy="82" r="14" fill="#22e6ff" />
+      <circle cx="40" cy="82" r="8" fill="#ffffff" opacity="0.9" />
+    </g>
+    <path d="M180 200l-86 110" stroke="#2cf0ff" stroke-width="10" stroke-linecap="round" />
+    <circle cx="94" cy="310" r="28" fill="#0b2b60" stroke="#48c0ff" stroke-width="6" />
+    <circle cx="94" cy="310" r="14" fill="#53f3ff" />
+    <path d="M94 310c-26 48-88 64-152 32" fill="none" stroke="#2cf0ff" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+  </g>
+  <g opacity="0.35" fill="#66d0ff">
+    <circle cx="240" cy="250" r="36" />
+    <circle cx="360" cy="220" r="18" />
+    <circle cx="520" cy="260" r="28" />
+    <circle cx="760" cy="220" r="18" />
+    <circle cx="900" cy="260" r="30" />
+    <circle cx="1080" cy="240" r="20" />
+  </g>
+</svg>

--- a/assets/su-tesisati-kurulumu-illustration.svg
+++ b/assets/su-tesisati-kurulumu-illustration.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1067" role="img" aria-labelledby="title desc">
+  <title id="title">Su tesisatı kurulumu illüstrasyonu</title>
+  <desc id="desc">Boru hatları ve plan çizgileriyle su tesisatı kurulumunu anlatan soyut görsel.</desc>
+  <defs>
+    <linearGradient id="kurulum-bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#091a2f" />
+      <stop offset="60%" stop-color="#123456" />
+      <stop offset="100%" stop-color="#166781" />
+    </linearGradient>
+    <linearGradient id="grid" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1a7aa7" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#0f3d59" stop-opacity="0.2" />
+    </linearGradient>
+    <linearGradient id="pipe-main" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#4fe0ff" />
+      <stop offset="100%" stop-color="#2fc3ff" />
+    </linearGradient>
+    <linearGradient id="pipe-secondary" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#5dffbf" />
+      <stop offset="100%" stop-color="#1dd0a5" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1067" fill="url(#kurulum-bg)" />
+  <g opacity="0.25" stroke="url(#grid)" stroke-width="4">
+    <path d="M160 120h1280v780H160z" fill="none" />
+    <g stroke-dasharray="4 18">
+      <path d="M160 220h1280" />
+      <path d="M160 320h1280" />
+      <path d="M160 420h1280" />
+      <path d="M160 520h1280" />
+      <path d="M160 620h1280" />
+      <path d="M160 720h1280" />
+      <path d="M160 820h1280" />
+    </g>
+    <g stroke-dasharray="4 18">
+      <path d="M320 120v780" />
+      <path d="M480 120v780" />
+      <path d="M640 120v780" />
+      <path d="M800 120v780" />
+      <path d="M960 120v780" />
+      <path d="M1120 120v780" />
+      <path d="M1280 120v780" />
+      <path d="M1440 120v780" />
+    </g>
+  </g>
+  <g fill="none" stroke-width="26" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M240 300h360c90 0 120 60 120 120s30 120 120 120h280" stroke="url(#pipe-main)" />
+    <path d="M520 540c80 0 120 40 120 120s56 120 132 120h368" stroke="url(#pipe-secondary)" />
+    <path d="M640 360v-80c0-60 40-110 120-110h280" stroke="url(#pipe-main)" />
+    <path d="M1120 620v160c0 70 42 120 120 120h160" stroke="url(#pipe-secondary)" />
+  </g>
+  <g fill="#0f2d45" opacity="0.7">
+    <circle cx="600" cy="300" r="44" />
+    <circle cx="880" cy="420" r="36" />
+    <circle cx="1180" cy="540" r="40" />
+    <circle cx="1360" cy="740" r="34" />
+  </g>
+  <g fill="#5dffbf" opacity="0.7">
+    <circle cx="600" cy="300" r="22" />
+    <circle cx="880" cy="420" r="18" />
+    <circle cx="1180" cy="540" r="20" />
+    <circle cx="1360" cy="740" r="18" />
+  </g>
+  <g transform="translate(1010 220)">
+    <rect x="0" y="0" width="340" height="200" rx="28" fill="#0f2d45" opacity="0.85" />
+    <rect x="20" y="26" width="300" height="148" rx="24" fill="#0d3c5c" />
+    <g fill="none" stroke="#48f0ff" stroke-width="10" stroke-linecap="round">
+      <path d="M56 96h96" />
+      <path d="M56 126h96" />
+    </g>
+    <g transform="translate(190 68)" fill="#5dffbf">
+      <circle cx="0" cy="0" r="26" opacity="0.9" />
+      <circle cx="58" cy="0" r="26" opacity="0.6" />
+      <circle cx="29" cy="52" r="20" opacity="0.8" />
+    </g>
+  </g>
+  <g opacity="0.35" fill="#4fe0ff">
+    <circle cx="260" cy="220" r="30" />
+    <circle cx="360" cy="180" r="18" />
+    <circle cx="460" cy="240" r="24" />
+    <circle cx="560" cy="200" r="20" />
+  </g>
+  <g opacity="0.3" fill="#1dd0a5">
+    <circle cx="1240" cy="260" r="22" />
+    <circle cx="1340" cy="220" r="16" />
+    <circle cx="1440" cy="280" r="20" />
+  </g>
+</svg>

--- a/assets/su-tesisati-tamirati-illustration.svg
+++ b/assets/su-tesisati-tamirati-illustration.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1067" role="img" aria-labelledby="title desc">
+  <title id="title">Su tesisatı tamiratı illüstrasyonu</title>
+  <desc id="desc">Su tesisatı onarımı için anahtar, contalar ve boru hatlarını gösteren illüstrasyon.</desc>
+  <defs>
+    <linearGradient id="tamir-bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1a2233" />
+      <stop offset="60%" stop-color="#2f3a56" />
+      <stop offset="100%" stop-color="#1f3c7a" />
+    </linearGradient>
+    <linearGradient id="wrench" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffd194" />
+      <stop offset="100%" stop-color="#f07f72" />
+    </linearGradient>
+    <linearGradient id="pipe-ring" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#63a4ff" />
+      <stop offset="100%" stop-color="#83eaf1" />
+    </linearGradient>
+    <linearGradient id="repair-pipe" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#40c9ff" />
+      <stop offset="100%" stop-color="#4a69ff" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1067" fill="url(#tamir-bg)" />
+  <g opacity="0.45">
+    <rect x="0" y="640" width="1600" height="200" fill="#131a2b" />
+    <rect x="0" y="840" width="1600" height="120" fill="#0d1422" />
+  </g>
+  <g fill="none" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.6">
+    <path d="M220 320h280c60 0 90 30 120 70l50 70c20 30 40 50 90 50h360c80 0 140 40 190 120l50 80" stroke="#50a0ff" />
+    <path d="M220 420h260c60 0 110 40 140 90l30 50c18 30 40 50 70 50h320c70 0 110 30 150 90l40 60" stroke="#20d0ff" opacity="0.5" />
+  </g>
+  <g transform="translate(320 280) rotate(-18)">
+    <rect x="0" y="0" width="440" height="120" rx="60" fill="url(#wrench)" />
+    <rect x="80" y="36" width="200" height="48" rx="24" fill="#fbe2cf" opacity="0.6" />
+    <circle cx="60" cy="60" r="36" fill="#fbe2cf" opacity="0.7" />
+    <circle cx="380" cy="60" r="36" fill="#fbe2cf" opacity="0.7" />
+  </g>
+  <g transform="translate(1040 360)">
+    <circle cx="120" cy="160" r="140" fill="none" stroke="url(#pipe-ring)" stroke-width="24" />
+    <circle cx="120" cy="160" r="80" fill="none" stroke="#a6f2ff" stroke-width="14" stroke-dasharray="30 24" opacity="0.6" />
+    <circle cx="120" cy="160" r="40" fill="#0e2238" stroke="#9cefff" stroke-width="12" />
+    <g transform="rotate(-28 120 160)">
+      <rect x="110" y="90" width="20" height="70" rx="10" fill="#9cefff" opacity="0.8" />
+      <rect x="116" y="110" width="8" height="30" rx="4" fill="#ffffff" opacity="0.8" />
+    </g>
+  </g>
+  <g transform="translate(980 640)">
+    <rect x="0" y="0" width="340" height="120" rx="40" fill="url(#repair-pipe)" />
+    <rect x="40" y="32" width="120" height="56" rx="20" fill="#0d1d44" />
+    <rect x="180" y="32" width="120" height="56" rx="20" fill="#0d1d44" />
+    <rect x="60" y="44" width="80" height="32" rx="16" fill="#4de7ff" opacity="0.8" />
+    <rect x="200" y="44" width="80" height="32" rx="16" fill="#4de7ff" opacity="0.8" />
+  </g>
+  <g opacity="0.35" fill="#4de7ff">
+    <circle cx="1260" cy="300" r="28" />
+    <circle cx="1340" cy="260" r="18" />
+    <circle cx="1420" cy="320" r="22" />
+    <circle cx="1500" cy="280" r="16" />
+  </g>
+  <g opacity="0.3" fill="#f07f72">
+    <circle cx="360" cy="200" r="26" />
+    <circle cx="440" cy="170" r="18" />
+    <circle cx="520" cy="210" r="20" />
+    <circle cx="600" cy="180" r="16" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -98,8 +98,8 @@
           <div class="relative overflow-hidden rounded-3xl bg-slate-900/30">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Photorealistic%20Turkish%20plumber%20using%20advanced%20leak%20detection%20equipment%20inside%20modern%20apartment%20bathroom%2C%20cinematic%20lighting%2C%20professional%20photography?width=1600&amp;height=1067"
-              alt="Gelişmiş cihazla su kaçağı tespiti yapan usta"
+              src="assets/su-kacagi-illustration.svg"
+              alt="Gelişmiş cihazla su kaçağı tespiti illüstrasyonu"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-[#0d1f4c]/90 via-[#0d1f4c]/80 to-[#143d7a]/70"></div>
             <div class="relative z-10 grid gap-10 px-6 py-16 md:grid-cols-[1.1fr_0.9fr] md:px-12 md:py-20">
@@ -193,8 +193,8 @@
               <figure class="relative h-52 overflow-hidden">
                 <img
                   class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-                  src="https://image.pollinations.ai/prompt/Photorealistic%20technician%20performing%20radiator%20flushing%20with%20professional%20cleaning%20machine%20in%20contemporary%20Turkish%20living%20room%2C%20warm%20lighting?width=1200&amp;height=800"
-                  alt="Profesyonel makinayla petek temizliği yapan teknisyen"
+                  src="assets/petek-temizligi-illustration.svg"
+                  alt="Profesyonel petek temizliği hizmetini anlatan illüstrasyon"
                 />
                 <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
               </figure>
@@ -224,8 +224,8 @@
               <figure class="relative h-52 overflow-hidden">
                 <img
                   class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-                  src="https://image.pollinations.ai/prompt/Photorealistic%20plumber%20repairing%20leaking%20pipe%20under%20kitchen%20sink%20with%20inspection%20camera%2C%20water%20droplets%2C%20dramatic%20lighting?width=1200&amp;height=800"
-                  alt="Mutfak lavabosu altında kaçak onarımı yapan usta"
+                  src="assets/su-tesisati-tamirati-illustration.svg"
+                  alt="Su tesisatı tamiratı hizmetini betimleyen illüstrasyon"
                 />
                 <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
               </figure>
@@ -255,8 +255,8 @@
               <figure class="relative h-52 overflow-hidden">
                 <img
                   class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-                  src="https://image.pollinations.ai/prompt/Photorealistic%20crew%20installing%20new%20PPR%20and%20copper%20water%20pipes%20on%20construction%20site%20interior%2C%20safety%20gear%2C%20daylight%20realism?width=1200&amp;height=800"
-                  alt="İnşaatta su tesisatı borularını döşeyen ekip"
+                  src="assets/su-tesisati-kurulumu-illustration.svg"
+                  alt="Yeni su tesisatı kurulumunu gösteren illüstrasyon"
                 />
                 <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
               </figure>
@@ -286,8 +286,8 @@
               <figure class="relative h-52 overflow-hidden">
                 <img
                   class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-                  src="https://image.pollinations.ai/prompt/Photorealistic%20Turkish%20HVAC%20technician%20installing%20wall-mounted%20combi%20boiler%20and%20modern%20panel%20radiator%20in%20bright%20utility%20room%2C%20face%20clearly%20visible%2C%20professional%20photography?width=1200&amp;height=800"
-                  alt="Yüzü görünen teknisyen kombi ve petek montajı yapıyor"
+                  src="assets/kombi-petek-montaj-illustration.svg"
+                  alt="Kombi ve petek montajı hizmetini anlatan illüstrasyon"
                 />
                 <div class="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
               </figure>

--- a/kombipetekmontaj.html
+++ b/kombipetekmontaj.html
@@ -99,8 +99,8 @@
           <div class="relative overflow-hidden rounded-3xl bg-slate-900/30">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Photorealistic%20Turkish%20technician%20servicing%20wall-mounted%20combi%20boiler%20with%20toolkit%2C%20face%20visible%2C%20bright%20apartment%20interior%2C%20professional%20photography?width=1600&amp;height=1067"
-              alt="Duvara monteli kombiyi servis eden yüzü görünen Türk teknisyen"
+              src="assets/kombi-petek-montaj-illustration.svg"
+              alt="Kombi ve petek montajını anlatan illüstrasyon"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-[#0d1f4c]/90 via-[#0d1f4c]/80 to-[#143d7a]/70"></div>
             <div class="relative z-10 grid gap-10 px-6 py-16 md:grid-cols-[1.1fr_0.9fr] md:px-12 md:py-20">
@@ -208,8 +208,8 @@
           <div class="relative h-full min-h-[320px]">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Professional%20installer%20mounting%20white%20panel%20radiator%20and%20balancing%20valves%20during%20heating%20system%20setup%2C%20photorealistic?width=1200&amp;height=800"
-              alt="Yeni panel peteği denge vanalarıyla monte eden usta"
+              src="assets/kombi-petek-montaj-illustration.svg"
+              alt="Kombi montajı detaylarını betimleyen illüstrasyon"
             />
             <div class="absolute inset-0 bg-gradient-to-t from-slate-900/70 via-slate-900/30 to-transparent"></div>
             <div class="absolute bottom-6 left-6 right-6 rounded-2xl bg-white/10 p-6 text-white shadow-lg backdrop-blur">

--- a/petektemizligi.html
+++ b/petektemizligi.html
@@ -98,8 +98,8 @@
           <div class="relative overflow-hidden rounded-3xl bg-slate-900/30">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Photorealistic%20radiator%20cleaning%20service%20with%20engineer%20connecting%20flushing%20machine%20to%20heaters%20in%20bright%20apartment%2C%20detailed%20realism?width=1600&amp;height=1067"
-              alt="Petek temizliği için flushing makinesi kuran uzman"
+              src="assets/petek-temizligi-illustration.svg"
+              alt="Petek temizliği hizmetini anlatan illüstrasyon"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-[#0d1f4c]/90 via-[#0d1f4c]/80 to-[#143d7a]/70"></div>
             <div class="relative z-10 grid gap-10 px-6 py-16 md:grid-cols-[1.1fr_0.9fr] md:px-12 md:py-20">
@@ -212,8 +212,8 @@
           <div class="relative h-full min-h-[320px]">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Close-up%20of%20professional%20hydronic%20radiator%20flushing%20machine%20hoses%20and%20gauges%20during%20cleaning%20service%2C%20photorealistic?width=1200&amp;height=800"
-              alt="Petek temizleme makinesi hortum ve manometreleri"
+              src="assets/petek-temizligi-illustration.svg"
+              alt="Petek temizleme ekipmanını gösteren illüstrasyon"
             />
             <div class="absolute inset-0 bg-gradient-to-t from-slate-900/70 via-slate-900/30 to-transparent"></div>
             <div class="absolute bottom-6 left-6 right-6 rounded-2xl bg-white/10 p-6 text-white shadow-lg backdrop-blur">

--- a/sutesisatikurulumu.html
+++ b/sutesisatikurulumu.html
@@ -98,8 +98,8 @@
           <div class="relative overflow-hidden rounded-3xl bg-slate-900/30">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Photorealistic%20water%20supply%20installation%20team%20laying%20new%20manifold%20and%20PEX%20pipes%20in%20modern%20building%20mechanical%20room%2C%20daylight%20realism?width=1600&amp;height=1067"
-              alt="Mekanik odada kolektör montajı yapan tesisat ekibi"
+              src="assets/su-tesisati-kurulumu-illustration.svg"
+              alt="Mekanik odada su tesisatı kurulumunu betimleyen illüstrasyon"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-[#0d1f4c]/90 via-[#0d1f4c]/80 to-[#143d7a]/70"></div>
             <div class="relative z-10 grid gap-10 px-6 py-16 md:grid-cols-[1.1fr_0.9fr] md:px-12 md:py-20">
@@ -207,8 +207,8 @@
           <div class="relative h-full min-h-[320px]">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Detailed%20view%20of%20plumbers%20aligning%20blue%20and%20red%20PPR%20pipes%20on%20ceiling%20with%20laser%20level%20during%20installation%2C%20photorealistic?width=1200&amp;height=800"
-              alt="Tavana boruları lazerle hizalayan ustalar"
+              src="assets/su-tesisati-kurulumu-illustration.svg"
+              alt="Su tesisatı kurulum sürecini anlatan illüstrasyon"
             />
             <div class="absolute inset-0 bg-gradient-to-t from-slate-900/70 via-slate-900/30 to-transparent"></div>
             <div class="absolute bottom-6 left-6 right-6 rounded-2xl bg-white/10 p-6 text-white shadow-lg backdrop-blur">

--- a/sutesisatitamirati.html
+++ b/sutesisatitamirati.html
@@ -98,8 +98,8 @@
           <div class="relative overflow-hidden rounded-3xl bg-slate-900/30">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Photorealistic%20leak%20detection%20expert%20scanning%20apartment%20corridor%20plumbing%20with%20thermal%20camera%20and%20acoustic%20sensor%2C%20cinematic%20lighting?width=1600&amp;height=1067"
-              alt="Termal kamera ile su kaçağı taraması yapan uzman"
+              src="assets/su-tesisati-tamirati-illustration.svg"
+              alt="Termal kamera ile su kaçağı tespitini anlatan illüstrasyon"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-[#0d1f4c]/90 via-[#0d1f4c]/80 to-[#143d7a]/70"></div>
             <div class="relative z-10 grid gap-10 px-6 py-16 md:grid-cols-[1.1fr_0.9fr] md:px-12 md:py-20">
@@ -208,8 +208,8 @@
           <div class="relative h-full min-h-[320px]">
             <img
               class="absolute inset-0 h-full w-full object-cover"
-              src="https://image.pollinations.ai/prompt/Professional%20plumber%20replacing%20damaged%20PPR%20water%20pipe%20behind%20opened%20wall%2C%20careful%20clean%20worksite%2C%20photorealistic?width=1200&amp;height=800"
-              alt="Açılan duvarda PPR boru değişimi yapan usta"
+              src="assets/su-tesisati-tamirati-illustration.svg"
+              alt="Su tesisatı tamir sürecini gösteren illüstrasyon"
             />
             <div class="absolute inset-0 bg-gradient-to-t from-slate-900/70 via-slate-900/30 to-transparent"></div>
             <div class="absolute bottom-6 left-6 right-6 rounded-2xl bg-white/10 p-6 text-white shadow-lg backdrop-blur">


### PR DESCRIPTION
## Summary
- remove the Python PNG generator and large binary image assets that were causing the unsupported binary error
- add lightweight SVG illustrations for each service category and leak detection hero section
- point every page to the new SVG artwork and refresh the alt text so imagery still describes each service accurately

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68d2ea8177b08325bc7ae3385ad0c090