### PR TITLE
Add Google Maps embed for shop location

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,6 +412,19 @@
               <a class="flex items-center gap-2 transition hover:text-white" href="#" aria-label="Facebook"><span class="material-icons text-base text-cyan-300">public</span><span>Facebook</span></a>
               <a class="flex items-center gap-2 transition hover:text-white" href="#" aria-label="YouTube"><span class="material-icons text-base text-cyan-300">smart_display</span><span>YouTube</span></a>
             </div>
+            <div class="mt-8 space-y-3">
+              <h5 class="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-300">Konumumuz</h5>
+              <div class="overflow-hidden rounded-2xl shadow-xl shadow-black/20 ring-1 ring-white/10">
+                <iframe
+                  class="h-64 w-full border-0"
+                  src="https://www.google.com/maps?q=D%26M%20Tesisat,%20%C4%B0stanbul%20ba%C4%9Fc%C4%B1lar%20velio%C4%9Flu%20caddesi,%201732.%20Sk%2019/A,%2034200%20Ba%C4%9Fc%C4%B1lar/%C4%B0stanbul&ftid=0x14caa50931fd3c49:0x3b2a7699ae2e3ae7&entry=gps&lucs=,94286594,94284481,94224825,94227247,94227248,94231188,47071704,47069508,94218641,94282134,94203019,47084304&g_st=ipc&output=embed"
+                  allowfullscreen=""
+                  loading="lazy"
+                  referrerpolicy="no-referrer-when-downgrade"
+                  title="D&amp;M Tesisat Konum Haritası"
+                ></iframe>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- embed the provided Google Maps location inside the contact section so visitors can easily find the shop

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d596c21bec83258215b3d1f30841f4